### PR TITLE
Update styles and improve range meter examples

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -13,6 +13,7 @@
     "beforeinput",
     "blazingly",
     "Blockquotes",
+    "blombard",
     "Bootstrappers",
     "borderless",
     "Brotli",

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@
 *.yml
 
 postcss.config.js
+.cspell.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,8 +43,8 @@
         "sass-true": "^8.1.0",
         "shelljs": "^0.10.0",
         "stylelint": "^16.21.0",
-        "stylelint-config-twbs-bootstrap": "^16.0.0",
-        "terser": "^5.43.0",
+        "stylelint-config-twbs-bootstrap": "^16.1.0",
+        "terser": "^5.43.1",
         "vnu-jar": "24.10.17"
       }
     },
@@ -4359,9 +4359,9 @@
       }
     },
     "node_modules/known-css-properties": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.35.0.tgz",
-      "integrity": "sha512-a/RAk2BfKk+WFGhhOCAYqSiFLc34k8Mt/6NWRI4joER0EYUzXIcFivjjnoD3+XU1DggLn/tZc3DOAgke7l8a4A==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.36.0.tgz",
+      "integrity": "sha512-A+9jP+IUmuQsNdsLdcg6Yt7voiMF/D4K83ew0OpJtpu+l34ef7LaohWV0Rc6KNvzw6ZDizkqfyB5JznZnzuKQA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4563,9 +4563,9 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.18.0.tgz",
-      "integrity": "sha512-gtCy1yim/vpHF/tq3B4Z43x3zKWpYeb4IM3d/Mf4oMYcNuoXOYEaqtoFlLHw9zd7+WNN3jNh6/WXyUrD3OIiwQ==",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.22.1.tgz",
+      "integrity": "sha512-u9Xnc9zLuF/CL2IHPow7HcXPpb8okQyzYpwL5wFsY//JRedSWYglYRg3PYWoQCu1zO+tBTmWOJN/iM0mPC5CRQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -6761,9 +6761,9 @@
       }
     },
     "node_modules/stylelint-config-twbs-bootstrap": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-twbs-bootstrap/-/stylelint-config-twbs-bootstrap-16.0.0.tgz",
-      "integrity": "sha512-MgFiCiqCZVUZ8Rt417lTPBnpgDgFsnZK1sy56UFL+niVLptO0kviKyzZB6b6yEU5bnlWRusau9/FgXiJOi2pJA==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-twbs-bootstrap/-/stylelint-config-twbs-bootstrap-16.1.0.tgz",
+      "integrity": "sha512-jp+/lHxOo5r21g05+qC/nbFueb7OH5Pub5SdWeBj7T0HVGuHDjB4NoNlWklmz1GsqNhAtFms6ZCnJsAgc8XOmQ==",
       "dev": true,
       "funding": [
         {
@@ -6782,7 +6782,7 @@
         "stylelint-config-recess-order": "^5.1.1",
         "stylelint-config-standard": "^36.0.1",
         "stylelint-config-standard-scss": "^14.0.0",
-        "stylelint-scss": "^6.11.1"
+        "stylelint-scss": "^6.12.1"
       },
       "engines": {
         "node": ">=18.12.0"
@@ -6805,16 +6805,16 @@
       }
     },
     "node_modules/stylelint-scss": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.11.1.tgz",
-      "integrity": "sha512-e4rYo0UY+BIMtGeGanghrvHTjcryxgZbyFxUedp8dLFqC4P70aawNdYjRrQxbnKhu3BNr4+lt5e/53tcKXiwFA==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.12.1.tgz",
+      "integrity": "sha512-UJUfBFIvXfly8WKIgmqfmkGKPilKB4L5j38JfsDd+OCg2GBdU0vGUV08Uw82tsRZzd4TbsUURVVNGeOhJVF7pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "css-tree": "^3.0.1",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.35.0",
-        "mdn-data": "^2.15.0",
+        "known-css-properties": "^0.36.0",
+        "mdn-data": "^2.21.0",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.6",
         "postcss-selector-parser": "^7.1.0",
@@ -7086,9 +7086,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.0.tgz",
-      "integrity": "sha512-CqNNxKSGKSZCunSvwKLTs8u8sGGlp27sxNZ4quGh0QeNuyHM0JSEM/clM9Mf4zUp6J+tO2gUXhgXT2YMMkwfKQ==",
+      "version": "5.43.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
+      "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -10664,9 +10664,9 @@
       "dev": true
     },
     "known-css-properties": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.35.0.tgz",
-      "integrity": "sha512-a/RAk2BfKk+WFGhhOCAYqSiFLc34k8Mt/6NWRI4joER0EYUzXIcFivjjnoD3+XU1DggLn/tZc3DOAgke7l8a4A==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.36.0.tgz",
+      "integrity": "sha512-A+9jP+IUmuQsNdsLdcg6Yt7voiMF/D4K83ew0OpJtpu+l34ef7LaohWV0Rc6KNvzw6ZDizkqfyB5JznZnzuKQA==",
       "dev": true
     },
     "levn": {
@@ -10803,9 +10803,9 @@
       "dev": true
     },
     "mdn-data": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.18.0.tgz",
-      "integrity": "sha512-gtCy1yim/vpHF/tq3B4Z43x3zKWpYeb4IM3d/Mf4oMYcNuoXOYEaqtoFlLHw9zd7+WNN3jNh6/WXyUrD3OIiwQ==",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.22.1.tgz",
+      "integrity": "sha512-u9Xnc9zLuF/CL2IHPow7HcXPpb8okQyzYpwL5wFsY//JRedSWYglYRg3PYWoQCu1zO+tBTmWOJN/iM0mPC5CRQ==",
       "dev": true
     },
     "memorystream": {
@@ -12326,9 +12326,9 @@
       }
     },
     "stylelint-config-twbs-bootstrap": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-twbs-bootstrap/-/stylelint-config-twbs-bootstrap-16.0.0.tgz",
-      "integrity": "sha512-MgFiCiqCZVUZ8Rt417lTPBnpgDgFsnZK1sy56UFL+niVLptO0kviKyzZB6b6yEU5bnlWRusau9/FgXiJOi2pJA==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-twbs-bootstrap/-/stylelint-config-twbs-bootstrap-16.1.0.tgz",
+      "integrity": "sha512-jp+/lHxOo5r21g05+qC/nbFueb7OH5Pub5SdWeBj7T0HVGuHDjB4NoNlWklmz1GsqNhAtFms6ZCnJsAgc8XOmQ==",
       "dev": true,
       "requires": {
         "@stylistic/stylelint-config": "^2.0.0",
@@ -12336,7 +12336,7 @@
         "stylelint-config-recess-order": "^5.1.1",
         "stylelint-config-standard": "^36.0.1",
         "stylelint-config-standard-scss": "^14.0.0",
-        "stylelint-scss": "^6.11.1"
+        "stylelint-scss": "^6.12.1"
       }
     },
     "stylelint-order": {
@@ -12350,15 +12350,15 @@
       }
     },
     "stylelint-scss": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.11.1.tgz",
-      "integrity": "sha512-e4rYo0UY+BIMtGeGanghrvHTjcryxgZbyFxUedp8dLFqC4P70aawNdYjRrQxbnKhu3BNr4+lt5e/53tcKXiwFA==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.12.1.tgz",
+      "integrity": "sha512-UJUfBFIvXfly8WKIgmqfmkGKPilKB4L5j38JfsDd+OCg2GBdU0vGUV08Uw82tsRZzd4TbsUURVVNGeOhJVF7pA==",
       "dev": true,
       "requires": {
         "css-tree": "^3.0.1",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.35.0",
-        "mdn-data": "^2.15.0",
+        "known-css-properties": "^0.36.0",
+        "mdn-data": "^2.21.0",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.6",
         "postcss-selector-parser": "^7.1.0",
@@ -12453,9 +12453,9 @@
       }
     },
     "terser": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.0.tgz",
-      "integrity": "sha512-CqNNxKSGKSZCunSvwKLTs8u8sGGlp27sxNZ4quGh0QeNuyHM0JSEM/clM9Mf4zUp6J+tO2gUXhgXT2YMMkwfKQ==",
+      "version": "5.43.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
+      "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
       "dev": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -93,8 +93,8 @@
     "sass-true": "^8.1.0",
     "shelljs": "^0.10.0",
     "stylelint": "^16.21.0",
-    "stylelint-config-twbs-bootstrap": "^16.0.0",
-    "terser": "^5.43.0",
+    "stylelint-config-twbs-bootstrap": "^16.1.0",
+    "terser": "^5.43.1",
     "vnu-jar": "24.10.17"
   },
   "files": [

--- a/site/assets/scss/_component-examples.scss
+++ b/site/assets/scss/_component-examples.scss
@@ -15,6 +15,13 @@
   }
 }
 
+.bd-example-resize {
+  min-width: 320px;
+  max-width: 777px;
+  overflow: auto;
+  resize: horizontal;
+}
+
 .bd-example {
   --bd-example-padding: 1rem;
 

--- a/site/static/dual-range-meter/index.html
+++ b/site/static/dual-range-meter/index.html
@@ -20,7 +20,7 @@
   </head>
 
   <body class="mt-5 overflow-hidden">
-    <div class="d-flex range-container mx-auto">
+    <main class="d-flex range-container mx-auto">
       <div class="mb-2">
         <h4>Temperature Threshold</h4>
       </div>
@@ -51,7 +51,7 @@
           <img src="mockup.png" alt="" class="text-center img-fluid" width="460" />
         </details>
       </div>
-    </div>
+    </main>
     <script>
 
     </script>

--- a/site/static/range-meter/index.html
+++ b/site/static/range-meter/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en" class="h-100 m-0 p-0">
+<html lang="en" class="h-100">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Range with Meter</title>
-    <meta name="description" content="Example Video Embed" />
+    <meta name="description" content="Example Range Meter" />
     <link href="https://cdn.jsdelivr.net/npm/@trimble-oss/modus-bootstrap/dist/css/modus-bootstrap.min.css" rel="stylesheet" />
 
     <style>
@@ -16,15 +16,23 @@
         background-position: bottom;
         font-size: 16px;
       }
+      .form-range::-moz-range-track {
+        background: linear-gradient(to right, #0063a3 0%, #0063a3 var(--value, 0%), #dee2e6 var(--value, 0%), #dee2e6 100%);
+      }
+      .form-range::-webkit-slider-runnable-track {
+        background: linear-gradient(to right, #0063a3 0%, #0063a3 var(--value, 0%), #dee2e6 var(--value, 0%), #dee2e6 100%);
+      }
     </style>
   </head>
 
-  <body class="h-100 text-center mt-5 overflow-hidden">
-    <div style="width: 308px" class="mx-auto">
-      <h3 class="text-start ms-0 mb-0 pb-0"><label for="rangeInput" class="">Road Risk Threshold</label></h1>
+  <body class="text-center mt-5 overflow-hidden">
+    <main style="width: 308px" class="mx-auto">
+      <h1 class="h3 text-start ms-0 mb-0 pb-0">
+        <label for="rangeInput" class="">Road Risk Threshold</label>
+      </h1>
       <br />
 
-      <div class="d-flex justify-content-between" style="margin-left:1px; margin-right:1px;">
+      <div class="d-flex justify-content-between" style="margin-left: 1px; margin-right: 1px">
         <div class="opacity-75 text-uppercase">No Risk</div>
         <div class="opacity-75 text-uppercase">Moderate</div>
         <div class="opacity-75 text-uppercase">High</div>
@@ -38,13 +46,7 @@
         <div class="opacity-50">8</div>
         <div class="opacity-50">10</div>
       </div>
-    </div>
-
-
-<style>
-.form-range::-moz-range-track{background:linear-gradient(to right, #0063a3 0%, #0063a3 var(--value, 0%), #dee2e6 var(--value, 0%), #dee2e6 100%)}
-.form-range::-webkit-slider-runnable-track{background:linear-gradient(to right, #0063a3 0%, #0063a3 var(--value, 0%), #dee2e6 var(--value, 0%), #dee2e6 100%)}
-</style>
+    </main>
 
     <script>
       // Getting all the range inputs
@@ -64,31 +66,6 @@
           range.style.setProperty("--value", `${value}%`);
         }
       });
-    </script>
-
-    <script>
-      // Example starter JavaScript for enabling form range
-      (() => {
-        "use strict";
-
-        // Getting all the range inputs
-        const ranges = document.querySelectorAll("#jsRange");
-
-        // Adding a listener to every input in order to have a dynamic progress
-        for (const range of ranges) {
-          range.addEventListener("input", () => {
-            const value = ((range.value - range.min) / (range.max - range.min)) * 100;
-            range.style.setProperty("--value", `${value}%`);
-          });
-        }
-
-        document.addEventListener("DOMContentLoaded", () => {
-          for (const range of ranges) {
-            const value = ((range.value - range.min) / (range.max - range.min)) * 100;
-            range.style.setProperty("--value", `${value}%`);
-          }
-        });
-      })();
     </script>
   </body>
 </html>


### PR DESCRIPTION
Added .bd-example-resize class for resizable examples in SCSS. Updated HTML structure in range meter examples to use <main> instead of <div>, improved accessibility, and cleaned up redundant scripts and styles. Also updated cspell dictionary and development dependencies for stylelint and terser.
