### PR TITLE
docs: Add Speculation Rules

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -146,6 +146,7 @@
     "Signin",
     "sirv",
     "socio",
+    "speculationrules",
     "srcset",
     "stackblitz",
     "stickied",

--- a/site/layouts/partials/meta.html
+++ b/site/layouts/partials/meta.html
@@ -68,3 +68,6 @@
   src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=default%2CNumber.parseInt%2CNumber.parseFloat%2CArray.prototype.find%2CArray.prototype.includes"></script>
 <script
   nomodule>window.MSInputMethodContext && document.documentMode && document.write('<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-ie11@5.3.4/css/bootstrap-ie11.min.css"><script src="https://cdn.jsdelivr.net/combine/npm/bootstrap@5.0.0-beta2/dist/js/bootstrap.bundle.min.js,npm/ie11-custom-properties@4,npm/element-qsa-scope@1"><\/script>');</script>
+<script type="speculationrules">
+{"prerender":[{"where":{"href_matches":"/*"},"eagerness":"moderate"}]}
+</script>


### PR DESCRIPTION
This pull request introduces a new feature to enable prerendering using speculation rules and updates the spell-check configuration to recognize a new term. Below are the key changes:

### Prerendering Feature:
* [`site/layouts/partials/meta.html`](diffhunk://#diff-5171ff5a3737b9181d6586ee55276f6220d514d0628ac847239d69f2eaece63dR71-R73): Added a `<script>` block with `type="speculationrules"` to define prerendering rules. This specifies moderate eagerness for prerendering pages matching the specified pattern.

### Spell-Check Configuration:
* [`.cspell.json`](diffhunk://#diff-4e0f175c840784de9e935f881821905c75a2a125aa57c51268a7fb4496edfbe6R149): Added the term "speculationrules" to the spell-check dictionary to prevent it from being flagged as a misspelling.