### PR TITLE
GitHub Actions Security Improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 1
     labels:
       - skip-changelog

--- a/.github/workflows/azure-static-web-apps-deploy.yml
+++ b/.github/workflows/azure-static-web-apps-deploy.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           submodules: recursive
           fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/cspell.yml
+++ b/.github/workflows/cspell.yml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
       - name: Run cspell
-        uses: streetsidesoftware/cspell-action@v7
+        uses: streetsidesoftware/cspell-action@dcd03dc3e8a59ec2e360d0c62db517baa0b4bb6d # v7.2.0
         with:
           config: ".cspell.json"
           files: "**/*.md"

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "${{ env.NODE }}"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/review-reminder.yml
+++ b/.github/workflows/review-reminder.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - uses: blombard/review-reminder@master
         with:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -14,13 +14,13 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v8
+        uses: super-linter/super-linter/slim@v8.1.0
         env:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: .*css/.*


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to improve security and maintainability by pinning action versions to specific commit SHAs, updating action versions, and adjusting automation schedules. The most notable changes are the migration from version tags to commit SHAs for critical actions, as well as updating the schedule for Dependabot updates.

**Workflow security and stability improvements:**

* All usages of `actions/checkout` across workflows (`azure-static-web-apps-deploy.yml`, `codeql.yml`, `cspell.yml`, `publish-to-npm.yml`, `review-reminder.yml`, `super-linter.yml`) are now pinned to the specific commit SHA for version 5.0.0, instead of using the version tag. This enhances security by preventing accidental updates and ensures reproducible builds. [[1]](diffhunk://#diff-f56718150ad81cc301d6693b0ff880df4943495658d85aa2a06200a5cd4b8443L11-R11) [[2]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L27-R27) [[3]](diffhunk://#diff-b5bea6479fd108441c7fc433db75bdd293b651be540c17849a44ed9d98d1c742L26-R31) [[4]](diffhunk://#diff-d308a7dcddbca8dc6670f9395563eb37abf617ff85a54f5e6bd12967b55d7b65L23-R23) [[5]](diffhunk://#diff-b98a0ab726b2a384efefb17113ab4277fc8ca884b4ef38fb14059e4ea858bf43L15-R15) [[6]](diffhunk://#diff-3336387af05d3a6efeaa358d145494d23b6036f9034efe8ff6edca2522f06c33L17-R23)

* `actions/setup-node` in `publish-to-npm.yml` is now pinned to its v5.0.0 commit SHA for improved security.

* `streetsidesoftware/cspell-action` in `cspell.yml` is now pinned to the v7.2.0 commit SHA instead of the version tag.

* `super-linter/super-linter/slim` in `super-linter.yml` is updated from v8 to v8.1.0 for the latest features and fixes.

**Automation schedule changes:**

* Dependabot's update interval for GitHub Actions in `.github/dependabot.yml` is changed from weekly to monthly, reducing the frequency of automated dependency update PRs.