### PR TITLE
Update super-linter.yml with permissions

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -6,11 +6,19 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   build:
     name: Lint Code Base
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
+
+    permissions:
+      contents: read
+      packages: read
+      # To report GitHub Actions status checks
+      statuses: write
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
This pull request makes improvements to the GitHub Actions workflow configuration by explicitly specifying permissions at both the workflow and job levels. This enhances security by following the principle of least privilege.

**Workflow and job permissions hardening:**

* Added an empty `permissions: {}` block at the workflow level in `.github/workflows/super-linter.yml` to remove default permissions for all jobs, ensuring no unnecessary permissions are granted.
* Added a `permissions` block at the job level to explicitly grant only the required permissions (`contents: read`, `packages: read`, and `statuses: write`) for the `build` job, improving security and clarity.