### PR TITLE
Remove Modus Design System entry and update URL

### DIFF
--- a/site/data/navbar_apps.yml
+++ b/site/data/navbar_apps.yml
@@ -1,10 +1,6 @@
-- title: Modus Design System
-  icon: "/img/icons/trimble.svg"
-  url: "https://modus.trimble.com/"
-
 - title: Modus Web Components
   icon: "/img/icons/web-components.svg"
-  url: "https://modus-web-components.trimble.com/"
+  url: "https://modus-web-components-v2.trimble.com/"
 
 - title: Modus Icons
   icon: "/img/icons/check-circle-outlined.svg"


### PR DESCRIPTION
This pull request updates the URL for the "Modus Web Components" entry in the `site/data/navbar_apps.yml` file to point to the new versioned site.

Navigation data update:

* Updated the `url` for "Modus Web Components" in `site/data/navbar_apps.yml` to `https://modus-web-components-v2.trimble.com/`.