### PR TITLE
fix security issue

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-      statuses: write
+      statuses: read
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
A minor update to the GitHub Actions workflow permissions.

The `statuses` permission for the `super-linter` workflow has been changed from `write` to `read`.

This reduces the workflow's access level, improving security by following the principle of least privilege.